### PR TITLE
Updatest test setup  

### DIFF
--- a/bundles/pubsub/test/CMakeLists.txt
+++ b/bundles/pubsub/test/CMakeLists.txt
@@ -318,7 +318,7 @@ celix_bundle_files(pubsub_deadlock_sut
         meta_data/deadlock.scope2.properties
         DESTINATION "META-INF/topics/pub"
         )
-
+target_link_libraries(pubsub_deadlock_sut PRIVATE Celix::pubsub_api)
 
 add_celix_container(pstm_deadlock_test
         USE_CONFIG #ensures that a config.properties will be created with the launch bundles.
@@ -340,6 +340,13 @@ celix_get_bundle_file(pubsub_deadlock_sut DEADLOCK_SUT_BUNDLE_FILE)
 target_compile_definitions(pstm_deadlock_test PRIVATE -DDEADLOCK_SUT_BUNDLE_FILE=\"${DEADLOCK_SUT_BUNDLE_FILE}\")
 target_link_libraries(pstm_deadlock_test PRIVATE Celix::pubsub_api GTest::gtest GTest::gtest_main Jansson Celix::dfi ZMQ::lib CZMQ::lib)
 target_include_directories(pstm_deadlock_test SYSTEM PRIVATE pstm_deadlock_test)
+
+#Note we do not link to bundles, as result (to ensure a bundle zip file is created) an dependency on the bundle is needed.
+add_dependencies(pstm_deadlock_test pubsub_deadlock_sut_bundle)
+
+#Framework "bundle" has no cache dir. Default as "cache dir" the cwd is used.
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/meta_data/msg.descriptor ${CMAKE_CURRENT_BINARY_DIR}/pstm_deadlock_test/META-INF/descriptors/msg.descriptor COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/meta_data/deadlock.scope.properties ${CMAKE_CURRENT_BINARY_DIR}/pstm_deadlock_test/META-INF/topics/pub/deadlock.properties COPYONLY)
 
 add_test(NAME pstm_deadlock_test COMMAND pstm_deadlock_test WORKING_DIRECTORY $<TARGET_PROPERTY:pstm_deadlock_test,CONTAINER_LOC>)
 setup_target_for_coverage(pstm_deadlock_test SCAN_DIR ..)

--- a/libs/framework/src/dm_dependency_manager_impl.c
+++ b/libs/framework/src/dm_dependency_manager_impl.c
@@ -27,6 +27,7 @@
 #include "dm_dependency_manager_impl.h"
 #include "celix_dependency_manager.h"
 #include "celix_bundle.h"
+#include "celix_framework.h"
 
 
 celix_dependency_manager_t* celix_private_dependencyManager_create(celix_bundle_context_t *context) {
@@ -159,7 +160,8 @@ static void celix_dm_getInfosCallback(void *handle, const celix_bundle_t *bnd) {
 
 celix_array_list_t * celix_dependencyManager_createInfos(celix_dependency_manager_t *manager) {
 	celix_array_list_t *infos = celix_arrayList_create();
-	celix_bundleContext_useBundles(manager->ctx, infos, celix_dm_getInfosCallback);
+	celix_framework_t* fw = celix_bundleContext_getFramework(manager->ctx);
+    celix_framework_useBundles(fw, true, infos, celix_dm_getInfosCallback);
 	return infos;
 }
 


### PR DESCRIPTION
also fixes an issue where the dm info for the framework was not retrieved.